### PR TITLE
Support Motor 1.0

### DIFF
--- a/henson_mongodb.py
+++ b/henson_mongodb.py
@@ -5,10 +5,7 @@ import pkg_resources
 import ssl
 
 from henson import Extension
-from motor.motor_asyncio import (
-    AsyncIOMotorClient,
-    AsyncIOMotorReplicaSetClient,
-)
+from motor.motor_asyncio import AsyncIOMotorClient
 from pymongo import uri_parser
 
 __all__ = ('MongoDB',)
@@ -74,22 +71,17 @@ class MongoDB(Extension):
         app.settings['MONGODB_CONNECT'] = info['options'].get(
             'auto_start_request', False)
 
-        # Replica sets require both a different client class and a
-        # different keyword argument name.
         if app.settings['MONGODB_REPLICA_SET']:
             kwargs['replicaSet'] = app.settings['MONGODB_REPLICA_SET']
-            _class = AsyncIOMotorReplicaSetClient
-        else:
-            _class = AsyncIOMotorClient
 
         host = app.settings['MONGODB_URI']
 
         kwargs['ssl'] = app.settings['MONGODB_USE_SSL']
 
         kwargs['document_class'] = app.settings['MONGODB_DOCUMENT_CLASS']
-        kwargs['max_pool_size'] = app.settings['MONGODB_MAX_POOL_SIZE']
+        kwargs['maxPoolSize'] = app.settings['MONGODB_MAX_POOL_SIZE']
         kwargs['tz_aware'] = app.settings['MONGODB_TIME_ZONE_AWARE']
-        kwargs['_connect'] = app.settings['MONGODB_CONNECT']
+        kwargs['connect'] = app.settings['MONGODB_CONNECT']
 
         self._auth = {
             'name': app.settings['MONGODB_USERNAME'],
@@ -121,7 +113,7 @@ class MongoDB(Extension):
                 'not at all.'
             )
 
-        self.client = _class(host, **kwargs)
+        self.client = AsyncIOMotorClient(host, **kwargs)
 
         # If a database name was provided, store the name so that the
         # db property can be used.

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     py_modules='henson_mongodb',
     install_requires=[
         'Henson',
-        'motor',
+        'motor>=1,<2',
     ],
     tests_require=[
         'pytest',

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,9 +1,6 @@
 """Test the configuration settings."""
 
-from motor.motor_asyncio import (
-    AsyncIOMotorClient,
-    AsyncIOMotorReplicaSetClient,
-)
+from motor.motor_asyncio import AsyncIOMotorClient
 import pytest
 
 from henson_mongodb import MongoDB
@@ -24,24 +21,9 @@ def test_no_database_valueerror(test_app):
         MongoDB(test_app)
 
 
-def test_no_replicaset(test_app):
-    """Test the client class when not using a replica set."""
-    mongo = MongoDB(test_app)
-
-    assert isinstance(mongo.client, AsyncIOMotorClient)
-
-
 def test_password_no_username_valueerror(test_app):
     """Test that only password and not username raises ValueError."""
     test_app.settings['MONGODB_URI'] = 'mongodb://testing@localhost/testing'
 
     with pytest.raises(ValueError):
         MongoDB(test_app)
-
-
-def test_replicaset(test_app):
-    """Test the client class when using a replica set."""
-    test_app.settings['MONGODB_URI'] += '?replicaset=testing'
-    mongo = MongoDB(test_app)
-
-    assert isinstance(mongo.client, AsyncIOMotorReplicaSetClient)


### PR DESCRIPTION
Motor 1.0 is a breaking change that switches from PyMongo 2.x to PyMongo
3.3. The most significant change is the removal of
`AsyncIOMotorReplicaSetClient`. PyMongo 3.3 introduced two additional
changes that currently affect Henson-MongoDB: `_current` has been
renamed to `current` and `max_pool_size` has been renamed to
`maxPoolSize`.

Versions of Motor beginning with 2.0 are explicitly excluded since 2.0
will be used to introduce breaking changes. Once such a release exists,
Henson-MongoDB will be updated accordingly.