### PR TITLE
Add a test for replica sets

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -26,3 +26,13 @@ def test_password_no_username_valueerror(test_app):
 
     with pytest.raises(ValueError):
         MongoDB(test_app)
+
+
+def test_replica_set(test_app):
+    """Test that replica sets get set correctly."""
+    test_app.settings['MONGODB_URI'] = (
+        'mongodb://testing:testing@localhost/testing?replicaSet=testing-rs'
+    )
+    mongo = MongoDB(test_app)
+
+    mongo.client.delegate._topology_settings._replica_set_name == 'testing-rs'


### PR DESCRIPTION
While this test is quite ugly, the presence of a replica set in the
connection URI causes `MongoDB.init_app` to follow a specific logic
branch it wouldn't otherwise follow. Having any test at all is a good
thing.